### PR TITLE
#137156977 Static Page Management

### DIFF
--- a/client/modules/accounts/templates/dropdown/dropdown.html
+++ b/client/modules/accounts/templates/dropdown/dropdown.html
@@ -36,7 +36,9 @@
     {{> userAccountsDropdown}}
     {{> tour}}
     {{> walletButton}}
-    {{> pages}}
+    {{#if hasAdminAccess}}
+      {{> pages}}
+    {{/if}}
     <!--administrative shortcut icons -->
     {{#each reactionApps provides="shortcut" enabled=true}}
       <li class="dropdown-apps-icon">

--- a/client/modules/accounts/templates/dropdown/dropdown.html
+++ b/client/modules/accounts/templates/dropdown/dropdown.html
@@ -36,6 +36,9 @@
     {{> userAccountsDropdown}}
     {{> tour}}
     {{> walletButton}}
+    {{#if currentUser}}
+      {{> visitPages}}
+    {{/if}}
     {{#if hasAdminAccess}}
       {{> pages}}
     {{/if}}
@@ -70,6 +73,17 @@
      <i class="fa fa-copy"></i>
      <span class="icon-text">
        Manage Pages
+     </span>
+   </a>
+  </li>
+</template>
+
+<template name="visitPages">
+  <li class="dropdown-apps-icon">
+   <a data-event-action="visit-pages" href={{slug}} class="visit-pages">
+     <i class="fa fa-file-powerpoint-o"></i>
+     <span class="icon-text">
+       Visit Pages
      </span>
    </a>
   </li>

--- a/client/modules/accounts/templates/dropdown/dropdown.html
+++ b/client/modules/accounts/templates/dropdown/dropdown.html
@@ -36,6 +36,7 @@
     {{> userAccountsDropdown}}
     {{> tour}}
     {{> walletButton}}
+    {{> pages}}
     <!--administrative shortcut icons -->
     {{#each reactionApps provides="shortcut" enabled=true}}
       <li class="dropdown-apps-icon">
@@ -51,15 +52,26 @@
 </template>
 
 <template name="tour">
-   <li class="dropdown-apps-icon">
-     <a onclick="reactionIntro()">
-       <i class="fa fa-plane fa-spin"></i>
-       <span class="icon-text">
-         Take-Tour
-       </span>
-     </a>
-   </li>
- </template>
+  <li class="dropdown-apps-icon">
+   <a onclick="reactionIntro()">
+     <i class="fa fa-plane fa-spin"></i>
+     <span class="icon-text">
+       Take-Tour
+     </span>
+   </a>
+  </li>
+</template>
+
+<template name="pages">
+  <li class="dropdown-apps-icon">
+   <a data-event-action="manage-pages">
+     <i class="fa fa-copy"></i>
+     <span class="icon-text">
+       Manage Pages
+     </span>
+   </a>
+  </li>
+</template>
 
 <template name="userAccountsDropdown">
   <!--user account shortcut icons -->

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -76,6 +76,10 @@ Template.loginDropdown.events({
       Reaction.Router.go(route);
     }
     template.$(".dropdown-toggle").dropdown("toggle");
+  },
+
+  "click [data-event-action=manage-pages]": function () {
+    Reaction.Router.go("/reaction/dashboard/static-pages");
   }
 });
 Template.walletButton.events({

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -10,6 +10,9 @@ Template.loginDropdown.helpers({
       six: "Access Quick Drop-down for Site Shortcuts and Profile"
     };
     return steps;
+  },
+  slug() {
+    return `/shop/${Reaction.getShopId()}`;
   }
 });
 
@@ -80,6 +83,11 @@ Template.loginDropdown.events({
 
   "click [data-event-action=manage-pages]": function () {
     Reaction.Router.go("/reaction/dashboard/static-pages");
+  },
+
+  "click [data-event-action=visit-pages]": function (event, template) {
+    event.preventDefault();
+    Reaction.Router.go(`/shop/${Reaction.getShopId()}`);
   }
 });
 

--- a/client/modules/accounts/templates/dropdown/dropdown.js
+++ b/client/modules/accounts/templates/dropdown/dropdown.js
@@ -82,6 +82,7 @@ Template.loginDropdown.events({
     Reaction.Router.go("/reaction/dashboard/static-pages");
   }
 });
+
 Template.walletButton.events({
   /**
  * wallet

--- a/client/modules/router/main.js
+++ b/client/modules/router/main.js
@@ -181,7 +181,7 @@ Router.initPackageRoutes = () => {
         ReactionLayout(Session.get("INDEX_OPTIONS") || {});
       }
     });
- 
+
     shop.route("/shop/:shopId", {
       action(params) {
         ReactionLayout({

--- a/client/modules/router/main.js
+++ b/client/modules/router/main.js
@@ -181,6 +181,15 @@ Router.initPackageRoutes = () => {
         ReactionLayout(Session.get("INDEX_OPTIONS") || {});
       }
     });
+ 
+    shop.route("/shop/:shopId", {
+      action(params) {
+        ReactionLayout({
+          template: "shopView",
+          data: params.shopId
+        });
+      }
+    });
 
     shop.route("/wallet", {
       name: "wallet",

--- a/client/templates/index.html
+++ b/client/templates/index.html
@@ -2,6 +2,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/intro.js/2.4.0/intro.js"></script>
   <script type="text/javascript" src="http://cdnjs.cloudflare.com/ajax/libs/d3/3.2.2/d3.v3.min.js"></script>
+  <script src="//cdn.ckeditor.com/4.6.2/standard/ckeditor.js"></script>
   <script src="https://js.paystack.co/v1/inline.js"></script>
   <script type="text/javascript">
     function reactionIntro() {

--- a/imports/plugins/core/layout/client/index.js
+++ b/imports/plugins/core/layout/client/index.js
@@ -19,7 +19,7 @@ import "./templates/layout/notice/unauthorized.html";
 import "./templates/layout/layout.html";
 import "./templates/layout/wallet/wallet.html";
 import "./templates/layout/wallet/wallet.js";
-
-
+import "./templates/layout/static-pages/shop-view.html";
+import "./templates/layout/static-pages/shop-view.js";
 import "./templates/theme/theme.html";
 import "./templates/theme/theme.js";

--- a/imports/plugins/core/layout/client/index.js
+++ b/imports/plugins/core/layout/client/index.js
@@ -20,5 +20,6 @@ import "./templates/layout/layout.html";
 import "./templates/layout/wallet/wallet.html";
 import "./templates/layout/wallet/wallet.js";
 
+
 import "./templates/theme/theme.html";
 import "./templates/theme/theme.js";

--- a/imports/plugins/core/layout/client/templates/layout/static-pages/shop-view.html
+++ b/imports/plugins/core/layout/client/templates/layout/static-pages/shop-view.html
@@ -1,0 +1,22 @@
+<template name="shopView">
+  <nav class="navbar navbar-inverse static-page-nav">
+    <div class="container">
+      <ul class="nav navbar-nav">
+        {{#each loadPages}}
+          <li><a href="#{{slug}}" data-event-action="{{slug}}">{{pageTitle}}</a></li>
+        {{/each}}
+      </ul>
+    </div>
+  </nav>
+  {{#each loadPages}}
+  <div class="row page-holder">
+    {{> page}}
+  </div>
+  {{/each}}
+</template>
+
+<template name="page">
+  <div class="col-sm-12" id="{{slug}}">
+    {{{content}}}
+  </div>
+</template>

--- a/imports/plugins/core/layout/client/templates/layout/static-pages/shop-view.js
+++ b/imports/plugins/core/layout/client/templates/layout/static-pages/shop-view.js
@@ -22,7 +22,6 @@ Template.shopView.helpers({
         status: 'publish'
       }]
     }).fetch();
-    console.log(pages);
     return pages;
   }
 });

--- a/imports/plugins/core/layout/client/templates/layout/static-pages/shop-view.js
+++ b/imports/plugins/core/layout/client/templates/layout/static-pages/shop-view.js
@@ -1,0 +1,28 @@
+import { Reaction } from '/client/api';
+import { Meteor } from 'meteor/meteor';
+import { Template } from 'meteor/templating';
+import { StaticPages } from '/lib/collections';
+
+import './shop-view.html';
+
+Template.shopView.onCreated(() => {
+  Meteor.subscribe('StaticPages');
+  const template = Template.instance();
+});
+
+Template.shopView.helpers({
+  getUrl() {
+    return `${window.location.host}/shop/${Reaction.getShopId()}`;
+  },
+
+  loadPages() {
+    const pages = StaticPages.find({
+      $and: [{
+        shopId: Reaction.getShopId(),
+        status: 'publish'
+      }]
+    }).fetch();
+    console.log(pages);
+    return pages;
+  }
+});

--- a/imports/plugins/core/layout/client/templates/layout/static-pages/shop-view.js
+++ b/imports/plugins/core/layout/client/templates/layout/static-pages/shop-view.js
@@ -1,13 +1,12 @@
-import { Reaction } from '/client/api';
-import { Meteor } from 'meteor/meteor';
-import { Template } from 'meteor/templating';
-import { StaticPages } from '/lib/collections';
+import { Reaction } from "/client/api";
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+import { StaticPages } from "/lib/collections";
 
-import './shop-view.html';
+import "./shop-view.html";
 
 Template.shopView.onCreated(() => {
-  Meteor.subscribe('StaticPages');
-  const template = Template.instance();
+  Meteor.subscribe("StaticPages");
 });
 
 Template.shopView.helpers({
@@ -19,7 +18,7 @@ Template.shopView.helpers({
     const pages = StaticPages.find({
       $and: [{
         shopId: Reaction.getShopId(),
-        status: 'publish'
+        status: "publish"
       }]
     }).fetch();
     return pages;

--- a/imports/plugins/included/default-theme/client/styles/main.less
+++ b/imports/plugins/included/default-theme/client/styles/main.less
@@ -141,3 +141,6 @@
 @import "search/results.less";
 @import "search/search-type-toggle.less";
 @import "search/sortable-table.less";
+
+// Static-page
+@import "static-pages/main.less";

--- a/imports/plugins/included/default-theme/client/styles/static-pages/main.less
+++ b/imports/plugins/included/default-theme/client/styles/static-pages/main.less
@@ -1,0 +1,196 @@
+.center { text-align: center; }
+
+.create-page {
+  height: 100px;
+
+  .heading {
+    height: 70px; 
+    max-width: 583px;
+    border-bottom: 1px solid #efefef;
+    margin-bottom: 30px;
+  }
+
+  .form-area {
+    max-width: 583px;
+  }
+
+  .error-span {
+    color: red;
+    font-size: 0.8em;
+    transition: all 0.3ms ease-out;
+    float: right;
+  }
+
+  .submit-btn {
+    margin-top: 20px;
+    background: #004faa;
+    color: #fff;
+    float: right;
+  }
+
+  .submit-btn:hover {
+    background: #01438e;
+  }
+  
+  .reset {
+    float: right;
+    display: block;
+    height: 30px;
+    text-align: center;
+    line-height: 30px;
+    border-radius: 5px;
+    background: #f00;
+    border: 1px solid #e00;
+    font-size: 0.8em;
+    margin-top: 20px;
+    padding-left: 10px;
+    padding-right: 10px;
+    color: #fff;
+  }
+
+  .reset:hover {
+    background: #a00;
+    cursor: pointer;
+  }
+
+  label > strong { color: #f00; }
+
+  input, textarea, .form-group-submit {
+    width: 100% !important;
+  }
+
+}
+
+.manage-pages {
+  min-height: 100px;
+  background-color: white;
+  border-left: 1px solid #efefef;
+  border-right: 1px solid #efefef;
+  padding-left: 10px;
+  padding-right: 10px;
+  padding-bottom: 10px;
+
+  .heading {
+    border-bottom: 1px solid #efefef;
+    height: 70px;
+  }
+
+  .drafts, .published {
+    text-align: center;
+    font-size: 1em;
+    box-sizing: border-box;
+  }
+
+  .drafts > div:first-child {
+    padding-top: 5px;
+    color: blue;
+    font-size: .7em;
+    text-transform: uppercase;
+  }
+
+  .published > div:first-child {
+    padding-top: 5px;
+    color: green;
+    font-size: .7em;
+    text-transform: uppercase;
+  }
+
+  .drafts > div:nth-child(2),
+  .published > div:nth-child(2) {
+    height: 50px;
+    font-size: 2em;
+    color: #000;
+  }
+
+  .table-display { margin-top: 30px; }
+
+  .edit:hover { color: green; }
+  .delete:hover { color: red; }
+  .edit:hover, .delete:hover {
+    cursor: pointer;
+  }
+
+  .switch {
+    position: relative;
+    display: inline-block;
+    width: 40px;
+    height: 22px;
+  }
+
+  .switch input {display:none;}
+
+  .slider {
+    position: absolute;
+    cursor: pointer;
+    top: 0;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    background-color: #ccc;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+
+  .slider:before {
+    position: absolute;
+    content: "";
+    height: 15px;
+    width: 15px;
+    left: 4px;
+    bottom: 4px;
+    background-color: white;
+    -webkit-transition: .4s;
+    transition: .4s;
+  }
+
+  input:checked + .slider {
+    background-color: #2196F3;
+  }
+
+  input:focus + .slider {
+    box-shadow: 0 0 1px #2196F3;
+  }
+
+  input:checked + .slider:before {
+    -webkit-transform: translateX(16px);
+    -ms-transform: translateX(16px);
+    transform: translateX(16px);
+  }
+
+  /* Rounded sliders */
+  .slider.round {
+    border-radius: 34px;
+  }
+
+  .slider.round:before {
+    border-radius: 50%;
+  }
+  
+}
+
+/** shop view **/
+
+.static-page-nav {
+  border-radius: 0 !important;
+}
+
+.static-page-nav ul li:hover {
+  background: black;
+}
+
+.static-page-nav ul li:hover a{
+  color: #fff !important;
+}
+
+.page-holder {
+  padding-left: 48px;
+  padding-right: 48px;
+  padding-top: 30px;
+  min-height: 500px;
+  border-bottom: 1px solid #efefef;
+}
+
+.page-holder:nth-child(even) {
+  background-color: #fff;
+}
+

--- a/imports/plugins/included/product-detail-simple/client/components/productDetail.js
+++ b/imports/plugins/included/product-detail-simple/client/components/productDetail.js
@@ -143,6 +143,7 @@ class ProductDetail extends Component {
 
             <div className="vendor">
                { this.renderVendorEdit() }
+               &nbsp;<a href={"/shop/" + this.product.shopId}><strong>Visit Shop</strong></a>
             </div>
 
             <div className="pdp product-info">

--- a/imports/plugins/included/static-pages/client/index.js
+++ b/imports/plugins/included/static-pages/client/index.js
@@ -1,0 +1,2 @@
+import "./templates/static-pages.html";
+import "./templates/static-pages.js";

--- a/imports/plugins/included/static-pages/client/template/static-pages.html
+++ b/imports/plugins/included/static-pages/client/template/static-pages.html
@@ -1,5 +1,0 @@
-<template name="staticPageLayout">
-  <div class="container" style="height: 300px; background: orange">
-    <h1>hello world</h1>
-  </div>
-</template>

--- a/imports/plugins/included/static-pages/client/template/static-pages.html
+++ b/imports/plugins/included/static-pages/client/template/static-pages.html
@@ -1,0 +1,5 @@
+<template name="staticPageLayout">
+  <div class="container" style="height: 300px; background: orange">
+    <h1>hello world</h1>
+  </div>
+</template>

--- a/imports/plugins/included/static-pages/client/templates/static-pages.html
+++ b/imports/plugins/included/static-pages/client/templates/static-pages.html
@@ -33,7 +33,7 @@
             <div>
               <div class="form-group-submit">
                 <label for="publish">
-                  <input type="checkbox" name="" id="publish" class="publish-page" value="publish">Save and Publish page.  
+                  <span><input type="checkbox" name="" id="publish" class="publish-page" value="publish">Save and Publish page.</span>
                 </label>
               </div>
               <div>

--- a/imports/plugins/included/static-pages/client/templates/static-pages.html
+++ b/imports/plugins/included/static-pages/client/templates/static-pages.html
@@ -1,7 +1,96 @@
 <template name="staticPageLayout">
-  <div class="container" style="height: 50px; background: orange">
-    <label for="">Page Title
-      <input type="text" name="" value="">
-    </label>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-8 create-page">
+        <div class="row heading">
+          <div class="col-md-8"><h2>Create a new page</h2></div>
+          <div class="col-md-4">
+            <span class="reset" data-event-action="formReset"><i class="fa fa-undo" aria-hidden="true"></i>&nbsp;Reset Form</span>
+          </div>
+        </div>
+        <div class="row form-area">
+          <form>
+            <div class="form-group">
+              <label>Title <strong>*</strong> </label>
+              <span id="titleErr" class="error-span"></span>
+              <input type="text" id="title" class="form-control tbox" placeholder="Page title">
+              <small class="form-text text-muted">This is your page title</small>
+            </div>
+            <label>Slug(url) <strong>*</strong></label>
+            <span id="slugErr" class="error-span"></span>
+            <div class="input-group">
+              <span class="input-group-addon">{{ getUrl }}/pages/</span>
+              <input type="text" id="slug" class="form-control tbox-2" placeholder="Slug">
+            </div><br>
+            <div class="input-group">
+              <label>Page Content</label>
+              <span id="contentErr" class="error-span"></span>
+              <textarea name="contentEditor" id="contentEditor" class="content-editor">
+                <h2>Page header</h2><hr>
+                <p>Page content</p>
+              </textarea>
+            </div>
+            <div>
+              <div class="form-group-submit">
+                <label for="publish">
+                  <input type="checkbox" name="" id="publish" class="publish-page" value="publish">Save and Publish page.  
+                </label>
+              </div>
+              <div>
+                <button type="submit" class="btn submit-btn" id="submitBtn" data-event-action="createPage">Save</button>
+              </div>
+            </div>
+          </form>  
+        </div>
+      </div>
+
+      {{#if getAllPages}}
+      <div class="col-md-4 manage-pages">
+        <div class="row heading">
+          <div class="col-md-6"><h3>My Pages</h3></div>
+          <div class="col-md-3 drafts">
+            <div>Drafts</div>
+            <div>{{fileStats.drafts}}</div>
+          </div>
+          <div class="col-md-3 published">
+            <div>Published</div>
+            <div>{{fileStats.published}}</div>
+          </div>
+        </div>
+
+        <div class="row table-display">
+          <table class="table table-hover">
+            <thead>
+              <tr>
+                <th>Page</th>
+                <th class="center">Publish</th>
+                <th class="center">Edit</th>
+                <th class="center">Delete</th>
+              </tr>  
+            </thead>
+            <tbody>
+            {{ #each getAllPages }}
+              {{> pageRow}}
+            {{ /each }}  
+            </tbody>
+          </table>
+        </div>
+      </div>
+      {{/if}}
+    </div>
   </div>
+</template>
+
+<template name="pageRow">
+  <tr>
+    <td>{{ pageTitle }}</td>
+    <td class="center">
+      <label class="switch">
+        <input type="checkbox" checked="{{#if equals status 'publish'}}checked{{/if}}" data-event-action="togglePublish">
+        <div class="slider round"></div>
+      </label>
+    </td>
+    <td class="center"><i class="fa fa-pencil edit" data-event-action="edit"></i></td>
+    <td class="center"><i class="fa fa-trash delete" data-event-action="delete"></i></td>
+  </tr>
 </template>

--- a/imports/plugins/included/static-pages/client/templates/static-pages.html
+++ b/imports/plugins/included/static-pages/client/templates/static-pages.html
@@ -1,7 +1,7 @@
 <template name="staticPageLayout">
   <div class="container">
     <div class="row">
-      <div class="col-md-8 create-page">
+      <div class="col-md-8 col-xs-12 create-page">
         <div class="row heading">
           <div class="col-md-8"><h2>Create a new page</h2></div>
           <div class="col-md-4">
@@ -45,7 +45,7 @@
       </div>
 
       {{#if getAllPages}}
-      <div class="col-md-4 manage-pages">
+      <div class="col-md-4 col-xs-12 manage-pages">
         <div class="row heading">
           <div class="col-md-6"><h3>My Pages</h3></div>
           <div class="col-md-3 drafts">

--- a/imports/plugins/included/static-pages/client/templates/static-pages.html
+++ b/imports/plugins/included/static-pages/client/templates/static-pages.html
@@ -1,0 +1,7 @@
+<template name="staticPageLayout">
+  <div class="container" style="height: 50px; background: orange">
+    <label for="">Page Title
+      <input type="text" name="" value="">
+    </label>
+  </div>
+</template>

--- a/imports/plugins/included/static-pages/client/templates/static-pages.js
+++ b/imports/plugins/included/static-pages/client/templates/static-pages.js
@@ -1,0 +1,10 @@
+import { Reaction } from "/lib/api";
+import { Meteor } from "meteor/meteor";
+import { Template } from "meteor/templating";
+import { StaticPages } from "/lib/collections";
+
+import "./static-pages.html";
+
+Template.staticPageLayout.onCreated(function () {
+  Meteor.subscribe("StaticPages");
+});

--- a/imports/plugins/included/static-pages/client/templates/static-pages.js
+++ b/imports/plugins/included/static-pages/client/templates/static-pages.js
@@ -1,10 +1,228 @@
-import { Reaction } from "/lib/api";
+import { Reaction } from "/client/api";
 import { Meteor } from "meteor/meteor";
 import { Template } from "meteor/templating";
 import { StaticPages } from "/lib/collections";
 
 import "./static-pages.html";
 
+// validate
+function validate(field, value) {
+
+  value = String.raw`${value}`;
+  
+  switch (field) {
+    case 'title': return validateTitle(value); break;
+    case 'slug': return validateSlug(value); break;
+    case 'content' : return validateContent(value); break;
+    default: null;
+  }
+
+  function validateTitle(title) {
+    if (!title || !/\w+/i.test(title)) return false;
+    return true;
+  }
+
+  function validateSlug(slug) {
+    if (!slug || !/[a-z]+(\/[a-z]+)*/g.test(slug)) return false;
+    return true;
+  }
+
+  function validateContent(content) {
+    if (!content || !/\w+/i.test(content)) return false;
+    return true;
+  }
+}
+
+// reset
+function reset() {
+  $('#title').val('');
+  $('#slug').val('');
+  CKEDITOR.instances["contentEditor"].setData('<h2>Page header</h2><hr><p>Page content</p>');
+}
+
 Template.staticPageLayout.onCreated(function () {
   Meteor.subscribe("StaticPages");
+  const template = Template.instance();
+});
+
+Template.staticPageLayout.onRendered(function () {
+  CKEDITOR.replace('contentEditor');
+});
+
+Template.staticPageLayout.helpers({
+  // create a new page
+  getUrl() {
+    return window.location.host;
+  },
+
+  // file stats
+  fileStats() {
+    const drafts = StaticPages.find({
+      $and: [{
+        shopId: Reaction.getShopId(),
+        status: 'draft'
+      }]
+    }).count();
+    const published = StaticPages.find({
+      $and: [{
+        shopId: Reaction.getShopId(),
+        status: 'publish'
+      }]
+    }).count();
+    
+    return {
+      drafts,
+      published
+    };
+  },
+
+  // fetch all pages
+  getAllPages() {
+    const pages = StaticPages.find().fetch();
+    pages.forEach(page => {
+      Session.set(page.pageTitle, page.status);
+    });
+    return pages;
+  }
+});
+
+Template.staticPageLayout.events({
+  /**
+   * createPage
+   * creates a new page
+   */ 
+  "click [data-event-action=createPage]": function (event, template) {
+    event.preventDefault();
+    template.pageDetails = {};
+    template.errors = {}
+
+    const title = template.$('#title').val().trim();
+    const slug = template.$('#slug').val().trim();
+    const content = CKEDITOR.instances["contentEditor"].getData();
+    const shopId = Reaction.getShopId();
+    const createdby = Meteor.userId();
+    
+    if (validate('title', title)) {
+      template.pageDetails.title = title[0].toUpperCase() + title.slice(1);
+    } else {
+      template.errors.title = 'Invalid title';
+    }
+
+    if (validate('slug', slug)) {
+      template.pageDetails.slug = slug.toLowerCase();
+    } else {
+      template.errors.slug = 'Invalid slug';
+    }
+
+    if (validate('content', content)) {
+      template.pageDetails.content = content;
+    } else {
+      template.errors.content = 'Invalid content';
+    }
+
+    if (template.$('#publish').prop('checked')) {
+      template.pageDetails.status = 'publish'
+    } else {
+      template.pageDetails.status = 'draft';
+    }
+
+    
+
+    if (!Object.keys(template.errors).length) {
+      if (template.$('#submitBtn').text().toLowerCase() === 'save') {
+        // append additional details to create new page
+        template.pageDetails.shopId = shopId;
+        template.pageDetails.createdby = createdby
+
+        Meteor.call("pages/createPage", template.pageDetails, (error, page) => {
+          if (!error) {
+            // run a page reset 
+            reset();
+            return Alerts.toast('Page successfully created.');
+          } else {
+            return Alerts.toast('Process failed! Unable to crate page.');
+          }
+        });  
+      } else {
+        // append additional details to create new page
+        template.pageDetails.pageId = Session.get('pageId')
+        
+        Meteor.call("pages/update", template.pageDetails, (error, page) => {
+          if (!error) {
+            // run a page reset 
+            reset();
+            $('.submit-btn').html('save');
+            $('h2').text('Create a new page');
+            return Alerts.toast('Page successfully updated.');
+          } else {
+            return Alerts.toast('Process failed! Unable to update.');
+          }
+        });
+      }
+    } else {
+      $('#titleErr').text(template.errors.title);
+      $('#slugErr').text(template.errors.slug); 
+      $('#contentErr').text(template.errors.content);
+    }
+  },
+
+  /**
+   * togglePublish
+   * changes the status of a page to publish if 
+   * the current state is draft and vice-versa
+   */ 
+  "change [data-event-action=togglePublish]": function (event) {
+    const pageId = this._id;
+    const status = event.target.checked ? 'publish' : 'draft';
+
+    Meteor.call('pages/togglePublish', status, pageId);
+  },
+
+  /**
+   * edit
+   * edits an existing page
+   */ 
+  "click [data-event-action=edit]": function () {
+    const pageId = this._id;
+    const currentPage = StaticPages.findOne({ _id: this._id });
+
+    Session.set("pageId", pageId);
+    if (!currentPage) return Alerts.toast('This page was not found');
+
+    $('#title').val(currentPage.pageTitle);
+    $('#slug').val(currentPage.slug);
+    CKEDITOR.instances["contentEditor"].setData(currentPage.content);
+    $('.submit-btn').html('update');
+    $('h2').text(`Edit ${currentPage.pageTitle}`);
+  },
+
+  /**
+   * delete
+   * deletes a single page
+   */ 
+  "click [data-event-action=delete]": function () {
+    const pageId = this._id;
+
+    Alerts.alert({
+      title: "Are you sure you want to delete this page?",
+      showCancelButton: true,
+      cancelButtonText: "No",
+      confirmButtonText: "Yes"
+    }, (confirmed) => {
+      if (confirmed) {
+        Meteor.call("pages/delete", pageId);
+      }
+    });
+  },
+
+  /**
+   * formReset
+   * sets the form to default
+   */ 
+  "click [data-event-action=formReset]": function (event, template) {
+    reset();
+    $('#titleErr').text(template.errors.title);
+    $('#slugErr').text(template.errors.slug); 
+    $('#contentErr').text(template.errors.content);
+  }
 });

--- a/imports/plugins/included/static-pages/client/templates/static-pages.js
+++ b/imports/plugins/included/static-pages/client/templates/static-pages.js
@@ -46,7 +46,7 @@ function validate(field, value) {
 function reset() {
   $("#title").val("");
   $("#slug").val("");
-  CKEDITOR.instances.contentEditor.setData("<h2>Page header</h2><hr><p>Page content</p>");
+  CKEDITOR.instances.$("contentEditor").attr("name").setData("<h2>Page header</h2><hr><p>Page content</p>");
 }
 
 Template.staticPageLayout.onCreated(function () {
@@ -110,8 +110,7 @@ Template.staticPageLayout.events({
 
     const title = template.$("#title").val().trim();
     const slug = template.$("#slug").val().trim();
-    const contentEditor = template.$("#contentEditor").attr("name");
-    const content = CKEDITOR.instances.contentEditor.getData();
+    const content = CKEDITOR.instances.$("#contentEditor").attr("name").getData();
     const shopId = Reaction.getShopId();
     const createdby = Meteor.userId();
 

--- a/imports/plugins/included/static-pages/client/templates/static-pages.js
+++ b/imports/plugins/included/static-pages/client/templates/static-pages.js
@@ -126,8 +126,6 @@ Template.staticPageLayout.events({
       template.pageDetails.status = 'draft';
     }
 
-    
-
     if (!Object.keys(template.errors).length) {
       if (template.$('#submitBtn').text().toLowerCase() === 'save') {
         // append additional details to create new page
@@ -144,7 +142,7 @@ Template.staticPageLayout.events({
           }
         });  
       } else {
-        // append additional details to create new page
+        // append additional details to update page
         template.pageDetails.pageId = Session.get('pageId')
         
         Meteor.call("pages/update", template.pageDetails, (error, page) => {

--- a/imports/plugins/included/static-pages/register.js
+++ b/imports/plugins/included/static-pages/register.js
@@ -1,0 +1,38 @@
+import { Reaction } from "/server/api";
+
+Reaction.registerPackage({
+  label: "Pages",
+  name: "Static Pages",
+  icon: "fa fa-copy",
+  autoEnable: true,
+  settings: {
+    name: "Static Pages"
+  },
+  registry: [{
+    route: "/dashboard/static-pages",
+    provides: "dashboard",
+    workflow: "corePagesWorkFlow",
+    name: "Static Pages",
+    label: "Pages",
+    description: "Create and Manage Static Pages",
+    icon: "fa fa-copy",
+    priority: 1,
+    container: "core",
+    template: "staticPageLayout"
+  }],
+  layout: [{
+    layout: "coreLayout",
+    workflow: "corePagesWorkFlow",
+    theme: "default",
+    enabled: true,
+    structure: {
+      template: "staticPageLayout",
+      layoutHeader: "layoutHeader",
+      layoutFooter: "layoutFooter",
+      notFound: "notFound",
+      dashboardHeader: "dashboardHeader",
+      dashboardControls: "dashboardControls",
+      adminControlsFooter: "adminControlsFooter"
+    }
+  }]
+});

--- a/imports/plugins/included/static-pages/register.js
+++ b/imports/plugins/included/static-pages/register.js
@@ -1,7 +1,7 @@
 import { Reaction } from "/server/api";
 
 Reaction.registerPackage({
-  label: "Pages",
+  label: "Static Pages",
   name: "Static Pages",
   icon: "fa fa-copy",
   autoEnable: true,
@@ -13,7 +13,7 @@ Reaction.registerPackage({
     provides: "dashboard",
     workflow: "corePagesWorkFlow",
     name: "Static Pages",
-    label: "Pages",
+    label: "Static Pages",
     description: "Create and Manage Static Pages",
     icon: "fa fa-copy",
     priority: 1,

--- a/lib/collections/collections.js
+++ b/lib/collections/collections.js
@@ -134,6 +134,13 @@ export const Shops = new Mongo.Collection("Shops");
 
 Shops.attachSchema(Schemas.Shop);
 
+/**
+* StaticPages Collection
+*/
+export const StaticPages = new Mongo.Collection("StaticPages");
+
+StaticPages.attachSchema(Schemas.StaticPages);
+
 
 /**
 * Tags Collection

--- a/lib/collections/schemas/index.js
+++ b/lib/collections/schemas/index.js
@@ -23,3 +23,4 @@ export * from "./translations";
 export * from "./workflow";
 export * from "./vendor";
 export * from "./wallets";
+export * from "./static-pages";

--- a/lib/collections/schemas/static-pages.js
+++ b/lib/collections/schemas/static-pages.js
@@ -1,6 +1,4 @@
-import { Random } from "meteor/random";
 import { SimpleSchema } from "meteor/aldeed:simple-schema";
-import { Metafield } from "./metafield";
 
 /**
 * Reaction Schemas Address

--- a/lib/collections/schemas/static-pages.js
+++ b/lib/collections/schemas/static-pages.js
@@ -26,6 +26,12 @@ export const StaticPages = new SimpleSchema({
     unique: true,
     optional: false
   },
+  status: {
+    label: "status",
+    type: String,
+    defaultValue: "draft",
+    optional: false
+  },
   createdby: {
     label: "Creator",
     type: String,
@@ -33,12 +39,10 @@ export const StaticPages = new SimpleSchema({
   },
   createdAt: {
     label: "Created at",
-    type: Date,
-    defaultValue: Date.now
+    type: Date
   },
   updatedAt: {
     label: "Updated at",
-    type: Date,
-    defaultValue: Date.now
+    type: Date
   }
 });

--- a/lib/collections/schemas/static-pages.js
+++ b/lib/collections/schemas/static-pages.js
@@ -1,0 +1,46 @@
+import { Random } from "meteor/random";
+import { SimpleSchema } from "meteor/aldeed:simple-schema";
+import { Metafield } from "./metafield";
+
+/**
+* Reaction Schemas Address
+*/
+
+export const StaticPages = new SimpleSchema({
+  shopId: {
+    type: String,
+    label: "Shop Id",
+    optional: false
+  },
+  pageTitle: {
+    type: String,
+    label: "Page Title",
+    optional: false
+  },
+  content: {
+    label: "Shop Address",
+    type: String,
+    optional: false
+  },
+  slug: {
+    label: "slug",
+    type: String,
+    unique: true,
+    optional: false
+  },
+  createdby: {
+    label: "Creator",
+    type: String,
+    optional: false
+  },
+  createdAt: {
+    label: "Created at",
+    type: Date,
+    defaultValue: Date.now
+  },
+  updatedAt: {
+    label: "Updated at",
+    type: Date,
+    defaultValue: Date.now
+  }
+});

--- a/server/methods/core/static-pages.js
+++ b/server/methods/core/static-pages.js
@@ -1,0 +1,110 @@
+import { Meteor } from "meteor/meteor";
+import { Reaction } from "/server/api";
+import { check } from "meteor/check";
+import { StaticPages } from "/lib/collections";
+import * as Schemas from "/lib/collections/schemas";
+
+/**
+ * Static Pages Methods
+ */
+Meteor.methods({
+ /**
+  * pages/createPage
+  * @param {Object} pageDetails - page details
+  * @return {Object} page - new page object
+  */
+  "pages/createPage": function (pageDetails) {
+    if (!Object.keys(pageDetails).length) return Meteor.error("error", "Cannot create empty page");
+
+    check(pageDetails.shopId, String);
+    check(pageDetails.pageTitle, String);
+    check(pageDetails.content, String);
+    check(pageDetails.slug, String);
+    check(pageDetails.createdby, String);
+
+    if (!Reaction.hasAdminAccess()) {
+      throw new Meteor.Error(403, "Access denied");
+    }
+
+    this.unblock();
+
+    if (StaticPages.find({ slug: slug }).count()) {
+      throw new Meteor.error("error", "This page already exists");
+    }
+
+    check(pageDetails, Schemas.StaticPages);
+    return StaticPages.insert(pageDetails);
+  },
+
+  /**
+   * pages/getAllPages
+   * @return {Object} pages - Array of page objects
+   */
+  "pages/getAllPages": function () {
+    const data = {};
+    const pages = StaticPages.findAll({ shopId: Reaction.getShopId() });
+
+    if (!pages.length) {
+      data.message = "No pages created yet!";
+      data.pages = null;
+    } else {
+      data.message = `${pages.length} pages active`;
+      data.pages = pages;
+    }
+
+    return data;
+  },
+
+  /**
+   * pages/getSinglePage
+   * @param {String} pageId
+   * @return {Object} page
+   */
+  "pages/getSinglePage": function (pageId) {
+    check(pageId, String);
+    this.unblock();
+
+    const page = StaticPages.findOne({ _id: pageId });
+    if (!page.count()) return Meteor.error(404, "Page not found");
+    return page;
+  },
+
+  /**
+   * pages/update
+   * @param {Object} updateFields - fields to be updated
+   * @param {String} pageId - fields to be updated
+   * @return {Object} updatedPage
+   */
+  "pages/update": function (updateFields, pageId) {
+    check(updateFields, Schemas.StaticPages);
+    check(pageId, String);
+
+    this.unblock();
+    const updatedPage = StaticPages.update(
+      { _id: pageId },
+      { $set: {
+        pageTitle: updateFields.pageTitle,
+        content: updateFields.content,
+        updatedAt: new Date
+      }
+      }
+    );
+    if (!updatedPage) return Meteor.error(404, "Unable to update this document.");
+    return updatedPage;
+  },
+
+  /**
+   * pages/delete
+   * @param {String} pageId - page id
+   * @return {Null} - no return value
+   */
+  "pages/delete": function (pageId) {
+    check(pageId, String);
+
+    this.unblock();
+    if (StaticPages.deleteOne({ _id: pageId })) {
+      return Alerts.toast("Page successfully deleted");
+    }
+    return Alerts.toast("Unable to delete page", "error");
+  }
+});

--- a/server/methods/core/static-pages.js
+++ b/server/methods/core/static-pages.js
@@ -30,7 +30,7 @@ Meteor.methods({
     this.unblock();
 
     const page = {
-      shopId : pageDetails.shopId,
+      shopId: pageDetails.shopId,
       pageTitle: pageDetails.title,
       content: pageDetails.content,
       slug: pageDetails.slug,
@@ -38,10 +38,10 @@ Meteor.methods({
       createdby: pageDetails.createdby,
       createdAt: new Date,
       updatedAt: new Date
-    }
+    };
 
     if (StaticPages.find({ slug: page.slug }).count()) {
-      Alerts.toast('This page already exists');
+      Alerts.toast("This page already exists");
     }
 
     check(page, Schemas.StaticPages);
@@ -50,9 +50,9 @@ Meteor.methods({
 
   /**
    * pages/togglePublish
-   * @param {Object} updateFields - fields to be updated
-   * @param {String} pageId - fields to be updated
-   * @return {Object} updatedPage
+   * @param {String} status - page status
+   * @param {String} pageId - page id
+   * @return {Null} no return value
    */
   "pages/togglePublish": function (status, pageId) {
     check(status, String);
@@ -71,8 +71,7 @@ Meteor.methods({
 
   /**
    * pages/update
-   * @param {Object} updateFields - fields to be updated
-   * @param {String} pageId - fields to be updated
+   * @param {Object} pageDetails - fields to be updated
    * @return {Object} updatedPage
    */
   "pages/update": function (pageDetails) {
@@ -108,6 +107,6 @@ Meteor.methods({
 
     this.unblock();
 
-    return StaticPages.remove({ _id: pageId });  
+    return StaticPages.remove({ _id: pageId });
   }
 });

--- a/server/methods/core/static-pages.js
+++ b/server/methods/core/static-pages.js
@@ -59,6 +59,7 @@ Meteor.methods({
     check(pageId, String);
 
     this.unblock();
+
     return StaticPages.update(
       { _id: pageId },
       { $set: {
@@ -82,6 +83,8 @@ Meteor.methods({
     check(pageDetails.status, String);
     check(pageDetails.pageId, String);
 
+    this.unblock();
+
     return StaticPages.update(
       { _id: pageDetails.pageId },
       { $set: {
@@ -104,7 +107,7 @@ Meteor.methods({
     check(pageId, String);
 
     this.unblock();
-    return StaticPages.remove({ _id: pageId });
-      
+
+    return StaticPages.remove({ _id: pageId });  
   }
 });

--- a/server/publications/collections/static-pages.js
+++ b/server/publications/collections/static-pages.js
@@ -1,7 +1,7 @@
 import { Meteor } from "meteor/meteor";
 import { StaticPages } from "/lib/collections";
 
-Meteor.publish("StaticPages", () => {
-  if (!this.userId) return this.ready();
+Meteor.publish("StaticPages", function () {
+  if (this.userId === null) return this.ready();
   return StaticPages.find();
 });

--- a/server/publications/collections/static-pages.js
+++ b/server/publications/collections/static-pages.js
@@ -1,0 +1,7 @@
+import { Meteor } from "meteor/meteor";
+import { StaticPages } from "/lib/collections";
+
+Meteor.publish("StaticPages", () => {
+  if (!this.userId) return this.ready();
+  return StaticPages.find();
+});

--- a/server/publications/collections/static-pages.js
+++ b/server/publications/collections/static-pages.js
@@ -2,6 +2,8 @@ import { Meteor } from "meteor/meteor";
 import { StaticPages } from "/lib/collections";
 
 Meteor.publish("StaticPages", function () {
-  if (this.userId === null) return this.ready();
+  if (this.userId === null) {
+    return this.ready();
+  }
   return StaticPages.find();
 });

--- a/server/security/policy.js
+++ b/server/security/policy.js
@@ -51,3 +51,4 @@ BrowserPolicy.content.allowOriginForAll("enginex.kadira.io");
 BrowserPolicy.content.allowOriginForAll("*.stripe.com");
 BrowserPolicy.content.allowOriginForAll("http://*.paystack.co");
 BrowserPolicy.content.allowOriginForAll("https://paystack.com");
+BrowserPolicy.content.allowOriginForAll("http://cdn.ckeditor.com");


### PR DESCRIPTION
### What does this PR do?
Allows shop admins/owners to create and manage static pages.

### Description of Task to be completed?
- Create a `View Pages` and `Manage Pages` links on the menu
- Create a page where admin gets to create and manage static pages
- Create a shop view where users get to see created pages
- Show a report of draft and published pages

### How should this be manually tested?
- From the admin menu, hit the `Manage Pages` link to go to page management
- Fill out the details of the new page
- Publish page
- Visit published pages via `Visit Pages` link on the menu (admin or user)

### Relevant Images
*Manage Pages*
![screencapture-localhost-3000-reaction-account-profile-1487601492302](https://cloud.githubusercontent.com/assets/23451281/23129363/a21c9bac-f782-11e6-99b7-a31f0312d38a.png)

*Static Page Creation Screen*
![screencapture-localhost-3000-reaction-dashboard-static-pages-1487601316157](https://cloud.githubusercontent.com/assets/23451281/23129277/4bb466c8-f782-11e6-87ad-ebab04cf01ac.png)

*Static Page User View*
![screencapture-localhost-3000-shop-j8bhq3uttdgwzx3rz-1487601421895](https://cloud.githubusercontent.com/assets/23451281/23129319/77ca24dc-f782-11e6-9721-0fa2aefb9f65.png)

### Relevant Pivotal Tracker Stories
#137156977 Static Page Management